### PR TITLE
#14 本番環境と開発環境で分ける

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,23 +1,30 @@
 # Use an official Node.js runtime as a parent image
 FROM node:18-slim
 
+# Set build-time argument (default is 'production')
+ARG NODE_ENV=production
+
+# Set the environment variable based on the build argument
+ENV NODE_ENV=${NODE_ENV}
+
 # Set the working directory in the container to /app
 WORKDIR /app
 
 # Copy the package.json and package-lock.json files to the container
 COPY package*.json ./
 
-# Install the application dependencies
-RUN npm install --production
+# Install dependencies based on the environment
+RUN if [ "$NODE_ENV" = "production" ]; then \
+      npm install --production; \
+    else \
+      npm install; \
+    fi
 
 # Copy the rest of the application code to the container
 COPY src/ ./src
 
 # Expose the port the app runs on
 EXPOSE 8080
-
-# Define environment variable for production
-ENV NODE_ENV=production
 
 # Run the application
 CMD ["node", "src/server.js"]

--- a/src/config.js
+++ b/src/config.js
@@ -8,8 +8,8 @@ const config = {
   NOTION_DATABASE_ID: process.env.NOTION_DATABASE_ID,
 
   development: {
-    GOAL_SETTING_CRON: '*/10 * * * *',   // 10分に1回
-    WEEKLY_REPORT_CRON: '*/10 * * * *'  // 10分に1回
+    GOAL_SETTING_CRON: '*/2 * * * *',   // 2分に1回
+    WEEKLY_REPORT_CRON: '*/2 * * * *'  // 2分に1回
   },
 
   production: {


### PR DESCRIPTION
## issue
- #14

Close #14 

## 作業内容
- dockerfileにNODE_ENVの引数を追加し、developmentとproductionによって分岐するように
- 開発環境（`development`）の場合
```
docker build --build-arg NODE_ENV=development -t yuru-sprint:dev .
docker run --name yuru-sprint --env-file .env.development -d -p 8080:8080 yuru-sprint:dev
```
- 本番環境（`production`）の場合
cd.yamlにて`NODE_ENV=production`を指定するようにする


## 動作確認方法
- 上記コマンドでローカルにて環境構築できることを確認
-  本番環境はこれから

## 今後の課題
-
