### PR TITLE
#10 仕上げ：DBへ所望の形式で渡す

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "npm run docker:build && npm run docker:run",
+    "stop": "npm run docker:stop && npm run docker:remove-image",
+    "docker:build": "docker build --build-arg NODE_ENV=development -t yuru-sprint:dev .",
+    "docker:run": "docker run --name yuru-sprint --env-file .env.development -d -p 8080:8080 yuru-sprint:dev",
+    "docker:stop": "docker stop yuru-sprint && docker rm yuru-sprint",
+    "docker:remove-image": "docker rmi yuru-sprint:dev"
   },
   "keywords": [],
   "author": "",

--- a/src/messages/weeklyReportMessage.js
+++ b/src/messages/weeklyReportMessage.js
@@ -1,4 +1,8 @@
-function weeklyReportMessage(formattedGoals, achievementRate) {
+function weeklyReportMessage(goals, achievementRate) {
+  const formattedGoals = goals.map((goal, index) => 
+    `${index + 1}. :${goal.emoji}: ${goal.text} ${goal.isCompleted ? "✅" : "⬜"}`
+  ).join('\n');
+
   return {
     blocks: [
       {
@@ -20,13 +24,6 @@ function weeklyReportMessage(formattedGoals, achievementRate) {
         text: {
           type: "mrkdwn",
           text: `全体の達成率: ${achievementRate}%`
-        }
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "今週の振り返りをしましょう！\n今週の目標達成状況を確認し、感想を入力してください。"
         }
       },
       {
@@ -53,16 +50,8 @@ function weeklyReportMessage(formattedGoals, achievementRate) {
               text: "送信",
               emoji: true
             },
+            value: JSON.stringify({ goals, achievementRate }),
             action_id: "submit_reflection"
-          }
-        ]
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "plain_text",
-            text: JSON.stringify({ formattedGoals, achievementRate })
           }
         ]
       }

--- a/src/messages/weeklyReportMessage.js
+++ b/src/messages/weeklyReportMessage.js
@@ -1,4 +1,4 @@
-function weeklyReportMessage(goals, achievementRate) {
+function weeklyReportMessage(goals, achievementRate, period) {
   const formattedGoals = goals.map((goal, index) => 
     `${index + 1}. :${goal.emoji}: ${goal.text} ${goal.isCompleted ? "✅" : "⬜"}`
   ).join('\n');
@@ -9,7 +9,7 @@ function weeklyReportMessage(goals, achievementRate) {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*今週の目標の振り返り*"
+          text: `*今週の目標の振り返り (${period})*`
         }
       },
       {
@@ -50,7 +50,7 @@ function weeklyReportMessage(goals, achievementRate) {
               text: "送信",
               emoji: true
             },
-            value: JSON.stringify({ goals, achievementRate }),
+            value: JSON.stringify({ goals, period }),
             action_id: "submit_reflection"
           }
         ]

--- a/src/modules/sendToNotionDB.js
+++ b/src/modules/sendToNotionDB.js
@@ -6,9 +6,8 @@ const cleanDatabaseId = config.NOTION_DATABASE_ID.trim().replace(/"/g, '');
 
 const notion = new Client({ auth: config.NOTION_INTEGRATION_TOKEN });
 
-async function sendWeeklyDataToNotion(completedTasks, incompleteTasks, achievementRate, feedback) {
+async function sendWeeklyDataToNotion(completedTasks, incompleteTasks, feedback) {
   try {
-    const today = new Date();
     const period = "8/19-8/25";
 
     console.log('Preparing data for Notion API');

--- a/src/modules/sendToNotionDB.js
+++ b/src/modules/sendToNotionDB.js
@@ -6,9 +6,8 @@ const cleanDatabaseId = config.NOTION_DATABASE_ID.trim().replace(/"/g, '');
 
 const notion = new Client({ auth: config.NOTION_INTEGRATION_TOKEN });
 
-async function sendWeeklyDataToNotion(completedTasks, incompleteTasks, feedback) {
+async function sendWeeklyDataToNotion(completedTasks, incompleteTasks, feedback, period) {
   try {
-    const period = "8/19-8/25";
 
     console.log('Preparing data for Notion API');
     const notionData = {

--- a/src/modules/weeklyReport.js
+++ b/src/modules/weeklyReport.js
@@ -17,10 +17,8 @@ async function generateWeeklyReport(slack, channelId) {
       return;
     }
 
-    // const formattedGoals = formatGoalStatuses(goalStatuses);
     const achievementRate = calculateAchievementRate(goalStatuses);
 
-    // const message = weeklyReportMessage(formattedGoals, achievementRate);
     const message = weeklyReportMessage(goalStatuses, achievementRate);
 
     await slack.chat.postMessage({
@@ -35,13 +33,6 @@ async function generateWeeklyReport(slack, channelId) {
   }
 }
 
-// function formatGoalStatuses(goalStatuses) {
-//   return goalStatuses.map((goal, index) => {
-//     const statusEmoji = goal.isCompleted ? "✅" : "⬜";
-//     return `${index + 1}. :${goal.emoji}: ${goal.text} ${statusEmoji}`;
-//   }).join('\n');
-// }
-
 function calculateAchievementRate(goalStatuses) {
   const completedGoals = goalStatuses.filter(goal => goal.isCompleted);
   return Math.round((completedGoals.length / goalStatuses.length) * 100);
@@ -54,7 +45,7 @@ async function handleUserFeedback(payload, slack, channelId) {
       throw new Error('Feedback is empty');
     }
 
-    const { goals, achievementRate } = JSON.parse(payload.actions[0].value);
+    const { goals } = JSON.parse(payload.actions[0].value);
     
     const completedTasks = goals.filter(goal => goal.isCompleted).map(goal => `${goal.emoji} ${goal.text}`);
     const incompleteTasks = goals.filter(goal => !goal.isCompleted).map(goal => `${goal.emoji} ${goal.text}`);
@@ -62,7 +53,6 @@ async function handleUserFeedback(payload, slack, channelId) {
     await sendWeeklyDataToNotion(
       completedTasks.join('\n') || 'なし',
       incompleteTasks.join('\n') || 'なし',
-      achievementRate,
       feedback
     );
 

--- a/src/server.js
+++ b/src/server.js
@@ -73,16 +73,12 @@ function createApp(testMode = false) {
         // 週終わりに送信した週間レポートのフィードバックを受け取る -> Notionに送信
         } else if (action.action_id === 'submit_reflection') {
           const userFeedback = payload.state.values.reflection_input.reflection_input.value;
-          const hiddenGoalsData = JSON.parse(payload.message.blocks[payload.message.blocks.length - 1].elements[0].text);
-        
-          console.log('User feedback:', userFeedback);
-          console.log('Hidden goals data:', hiddenGoalsData);
           
           if (!userFeedback) {
             throw new Error('User feedback is empty');
           }
           
-          await weeklyReport.handleUserFeedback(userFeedback, hiddenGoalsData, slack, payload.channel.id);
+          await weeklyReport.handleUserFeedback(payload, slack, payload.channel.id);
         }
       } catch (error) {
         console.error('Error handling action:', error);


### PR DESCRIPTION
## issue
- #10 

Close #10

## 作業内容
-  DBへ渡すカラムをSlackメッセージ経由で受け取る方法
- 完了タスクと未完了タスクを分離して、DBへ渡す
- 日付を動的取得

## 動作確認方法
- 開発環境にて、Notonへ所望の形式で渡せることを確認

## 今後の課題
-
