### PR TITLE
#18 絵文字のランダム選択が重複しないように実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.7.4",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "lodash": "^4.17.21",
         "node-schedule": "^2.1.1"
       }
     },
@@ -581,6 +582,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/long-timeout": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.7.4",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "lodash": "^4.17.21",
     "node-schedule": "^2.1.1"
   }
 }

--- a/src/modules/goalSetting.js
+++ b/src/modules/goalSetting.js
@@ -1,11 +1,14 @@
-const {
-  goalSettingMessage,
-  updateGoalSettingMessage,
-} = require("../messages/goalSettingMessage");
+const _ = require('lodash');
 const { emojiMapping } = require("../utils/emojiMapping");
+const { goalSettingMessage, updateGoalSettingMessage } = require("../messages/goalSettingMessage");
 
 let currentGoals = [];
 const MAX_GOALS = 15; // 最大目標数を定数として定義
+
+function getRandomEmojis(count) {
+  const allEmojis = Object.keys(emojiMapping);
+  return _.shuffle(allEmojis).slice(0, count);
+}
 
 async function initiateGoalSetting(slack, channelId) {
   currentGoals = []; // 目標リストをリセット
@@ -23,7 +26,6 @@ async function initiateGoalSetting(slack, channelId) {
 
 async function handleGoalSubmission(payload, slack, channelId) {
   if (currentGoals.length >= MAX_GOALS) {
-    // 最大目標数に達している場合、エラーメッセージを返す
     try {
       await slack.chat.postEphemeral({
         channel: payload.channel.id,
@@ -33,22 +35,15 @@ async function handleGoalSubmission(payload, slack, channelId) {
     } catch (error) {
       console.error("Error sending ephemeral message:", error);
     }
-    return; // 処理を終了
+    return;
   }
 
   const goalText = payload.state.values.goal_input.goal_value.value;
-  const emoji =
-    payload.state.values.emoji_input.emoji_value.selected_option.value;
+  const emoji = payload.state.values.emoji_input.emoji_value.selected_option.value;
 
   currentGoals.push({ text: goalText, emoji: emoji });
 
   const dynamicChannelId = payload.channel.id;
-
-  console.log("Updating message with:", {
-    channel: dynamicChannelId,
-    ts: payload.message.ts,
-    goals: currentGoals,
-  });
 
   try {
     const result = await slack.chat.update({
@@ -64,10 +59,10 @@ async function handleGoalSubmission(payload, slack, channelId) {
 }
 
 async function finalizeGoalSetting(payload, slack, channelId) {
-  // ランダムに絵文字を選択
-  const goalsWithRandomEmoji = currentGoals.map((goal) => ({
+  const randomEmojis = getRandomEmojis(currentGoals.length);
+  const goalsWithRandomEmoji = currentGoals.map((goal, index) => ({
     text: goal.text,
-    emoji: getRandomEmoji(),
+    emoji: randomEmojis[index],
   }));
 
   const goalListText = formatGoalList(goalsWithRandomEmoji);
@@ -78,12 +73,10 @@ async function finalizeGoalSetting(payload, slack, channelId) {
       text: `今週の目標です：\n${goalListText}`,
     });
 
-    // 各目標の絵文字でリアクションを追加
     for (const goal of goalsWithRandomEmoji) {
       await addReactionToMessage(slack, channelId, result.ts, goal.emoji);
     }
 
-    // 以前の目標設定メッセージを削除
     await slack.chat.delete({
       channel: channelId,
       ts: payload.message.ts,
@@ -112,12 +105,6 @@ function formatGoalList(goals) {
   return goals
     .map((goal, index) => `${index + 1}. ${goal.text} :${goal.emoji}:`)
     .join("\n");
-}
-
-function getRandomEmoji() {
-  const emojiKeys = Object.keys(emojiMapping);
-  const randomIndex = Math.floor(Math.random() * emojiKeys.length);
-  return emojiKeys[randomIndex];
 }
 
 module.exports = {

--- a/src/utils/emojiMapping.js
+++ b/src/utils/emojiMapping.js
@@ -9,7 +9,6 @@ const emojiMapping = {
   rocket: { reaction: 'rocket', notion: '🚀' },
   lipstick: { reaction: 'lipstick', notion: '💄' },
   tada: { reaction: 'tada', notion: '🎉' },
-  white_check_mark: { reaction: 'white_check_mark', notion: '✅' },
   lock: { reaction: 'lock', notion: '🔒️' },
   closed_lock_with_key: { reaction: 'closed_lock_with_key', notion: '🔐' },
   bookmark: { reaction: 'bookmark', notion: '🔖' },


### PR DESCRIPTION
## issue
- #18

Close #18

## 作業内容
-  絵文字マップ用意
- 標準絵文字とslackのスタンプのコマンドを対応付け
- 目標上限数を設定
- 絵文字が被らないように、ランダム選択

## 動作確認方法
- 開発環境にて確認

## 今後の課題
- 目標リストは変数でサーバー側で管理してしまっている。修正しないとユーザー共有で使えなさそう
