### PR TITLE
#23 目標設定時の諸処理実装

### DIFF
--- a/src/messages/goalSettingMessage.js
+++ b/src/messages/goalSettingMessage.js
@@ -28,59 +28,6 @@ const goalSettingMessage = {
       }
     },
     {
-      type: "input",
-      block_id: "emoji_input",
-      element: {
-        type: "static_select",
-        action_id: "emoji_value",
-        placeholder: {
-          type: "plain_text",
-          text: "絵文字を選択してください"
-        },
-        options: [
-          {
-            text: {
-              type: "plain_text",
-              text: "🎯 Target"
-            },
-            value: "dart"
-          },
-          {
-            text: {
-              type: "plain_text",
-              text: "💪 Muscle"
-            },
-            value: "muscle"
-          },
-          {
-            text: {
-              type: "plain_text",
-              text: "🏆 Trophy"
-            },
-            value: "trophy"
-          },
-          {
-            text: {
-              type: "plain_text",
-              text: "📚 Book"
-            },
-            value: "book"
-          },
-          {
-            text: {
-              type: "plain_text",
-              text: "💻 Computer"
-            },
-            value: "computer"
-          }
-        ]
-      },
-      label: {
-        type: "plain_text",
-        text: "絵文字"
-      }
-    },
-    {
       type: "actions",
       elements: [
         {
@@ -139,7 +86,7 @@ function updateGoalSettingMessage(goals) {
       type: "context",
       elements: goals.map((goal, index) => ({
         type: "mrkdwn",
-        text: `:${goal.emoji}: ${goal.text}`
+        text: `${index + 1}. ${goal.text}`
       }))
     };
 

--- a/src/messages/goalSettingMessage.js
+++ b/src/messages/goalSettingMessage.js
@@ -1,167 +1,178 @@
 require('dotenv').config();
 
-const MAX_GOALS = 15; // 最大目標数を定数として定義
+const MAX_GOALS = 15;
 
 const goalSettingMessage = {
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `<@${process.env.SLACK_USER_ID}>\n今週の目標を入力してください：`
-        }
-      },
-      {
-        type: "input",
-        block_id: "goal_input",
-        element: {
-          type: "plain_text_input",
-          action_id: "goal_value",
-          placeholder: {
-            type: "plain_text",
-            text: "目標を入力してください"
-          }
-        },
-        label: {
-          type: "plain_text",
-          text: "目標"
-        }
-      },
-      {
-        type: "input",
-        block_id: "emoji_input",
-        element: {
-          type: "static_select",
-          action_id: "emoji_value",
-          placeholder: {
-            type: "plain_text",
-            text: "絵文字を選択してください"
-          },
-          options: [
-            {
-              text: {
-                type: "plain_text",
-                text: "🎯 Target"
-              },
-              value: "dart"
-            },
-            {
-              text: {
-                type: "plain_text",
-                text: "💪 Muscle"
-              },
-              value: "muscle"
-            },
-            {
-              text: {
-                type: "plain_text",
-                text: "🏆 Trophy"
-              },
-              value: "trophy"
-            },
-            {
-              text: {
-                type: "plain_text",
-                text: "📚 Book"
-              },
-              value: "book"
-            },
-            {
-              text: {
-                type: "plain_text",
-                text: "💻 Computer"
-              },
-              value: "computer"
-            }
-          ]
-        },
-        label: {
-          type: "plain_text",
-          text: "絵文字"
-        }
-      },
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            text: {
-              type: "plain_text",
-              text: "追加"
-            },
-            style: "primary",
-            action_id: "add_goal"
-          }
-        ]
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*今週の目標リスト：*"
-        }
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "目標はまだ追加されていません。"
-          }
-        ]
-      },
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            text: {
-              type: "plain_text",
-              text: "目標設定完了"
-            },
-            style: "danger",
-            action_id: "finalize_goals"
-          }
-        ]
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<@${process.env.SLACK_USER_ID}>\n今週の目標を入力してください：`
       }
-    ]
-  };
-  
-  function updateGoalSettingMessage(goals) {
-    const updatedBlocks = [...goalSettingMessage.blocks];
-  
-    // 目標リストの更新
-    const goalListIndex = updatedBlocks.findIndex(block =>
-      block.type === "section" && block.text.text === "*今週の目標リスト：*"
-    );
-  
-    // 目標がある場合はリストを更新
-    if (goals.length > 0) {
-      updatedBlocks[goalListIndex + 1] = {
-        type: "context",
-        elements: goals.map(goal => ({
-          type: "mrkdwn",
-          text: `:${goal.emoji}: ${goal.text}`
-        }))
-      };
-    }
-  
-    // 目標数が上限に達した場合のメッセージを追加
-    if (goals.length >= MAX_GOALS) {
-      updatedBlocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `:warning: 目標の数が上限（${MAX_GOALS}個）に達しています。これ以上追加できません。`
+    },
+    {
+      type: "input",
+      block_id: "goal_input",
+      element: {
+        type: "plain_text_input",
+        action_id: "goal_value",
+        placeholder: {
+          type: "plain_text",
+          text: "目標を入力してください"
         }
-      });
+      },
+      label: {
+        type: "plain_text",
+        text: "目標"
+      }
+    },
+    {
+      type: "input",
+      block_id: "emoji_input",
+      element: {
+        type: "static_select",
+        action_id: "emoji_value",
+        placeholder: {
+          type: "plain_text",
+          text: "絵文字を選択してください"
+        },
+        options: [
+          {
+            text: {
+              type: "plain_text",
+              text: "🎯 Target"
+            },
+            value: "dart"
+          },
+          {
+            text: {
+              type: "plain_text",
+              text: "💪 Muscle"
+            },
+            value: "muscle"
+          },
+          {
+            text: {
+              type: "plain_text",
+              text: "🏆 Trophy"
+            },
+            value: "trophy"
+          },
+          {
+            text: {
+              type: "plain_text",
+              text: "📚 Book"
+            },
+            value: "book"
+          },
+          {
+            text: {
+              type: "plain_text",
+              text: "💻 Computer"
+            },
+            value: "computer"
+          }
+        ]
+      },
+      label: {
+        type: "plain_text",
+        text: "絵文字"
+      }
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "追加"
+          },
+          style: "primary",
+          action_id: "add_goal"
+        }
+      ]
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*今週の目標リスト：*"
+      }
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "目標はまだ追加されていません。"
+        }
+      ]
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "目標設定完了"
+          },
+          style: "danger",
+          action_id: "finalize_goals"
+        }
+      ]
     }
-  
-    return { blocks: updatedBlocks };
+  ]
+};
+
+function updateGoalSettingMessage(goals) {
+  const updatedBlocks = [...goalSettingMessage.blocks];
+
+  const goalListIndex = updatedBlocks.findIndex(block =>
+    block.type === "section" && block.text.text === "*今週の目標リスト：*"
+  );
+
+  if (goals.length > 0) {
+    updatedBlocks[goalListIndex + 1] = {
+      type: "context",
+      elements: goals.map((goal, index) => ({
+        type: "mrkdwn",
+        text: `:${goal.emoji}: ${goal.text}`
+      }))
+    };
+
+    // Add delete buttons for each goal with unique action_ids
+    updatedBlocks.splice(goalListIndex + 2, 0, {
+      type: "actions",
+      elements: goals.map((goal, index) => ({
+        type: "button",
+        text: {
+          type: "plain_text",
+          text: "削除"
+        },
+        style: "danger",
+        action_id: `delete_goal_${index}`,
+        value: index.toString()
+      }))
+    });
   }
-  
-  module.exports = {
-    goalSettingMessage,
-    updateGoalSettingMessage
-  };
-  
+
+  if (goals.length >= MAX_GOALS) {
+    updatedBlocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:warning: 目標の数が上限（${MAX_GOALS}個）に達しています。これ以上追加できません。`
+      }
+    });
+  }
+
+  return { blocks: updatedBlocks };
+}
+
+module.exports = {
+  goalSettingMessage,
+  updateGoalSettingMessage
+};

--- a/src/modules/goalSetting.js
+++ b/src/modules/goalSetting.js
@@ -39,9 +39,8 @@ async function handleGoalSubmission(payload, slack, channelId) {
   }
 
   const goalText = payload.state.values.goal_input.goal_value.value;
-  const emoji = payload.state.values.emoji_input.emoji_value.selected_option.value;
 
-  currentGoals.push({ text: goalText, emoji: emoji });
+  currentGoals.push({ text: goalText });
 
   try {
     const result = await slack.chat.update({
@@ -140,8 +139,8 @@ async function getCurrentGoals(slack, channelId, messageTs) {
 
       if (goalListBlock) {
         return goalListBlock.elements.map(element => {
-          const match = element.text.match(/:(\w+): (.+)/);
-          return match ? { emoji: match[1], text: match[2] } : null;
+          const match = element.text.match(/\d+\.\s(.+)/);
+          return match ? { text: match[1] } : null;
         }).filter(Boolean);
       }
     }

--- a/src/modules/statusDetector.js
+++ b/src/modules/statusDetector.js
@@ -24,7 +24,7 @@ async function detectStatuses(slack, channelId) {
     );
 
     const endDate = new Date().toISOString().split("T")[0]; // 今日の日付
-    const period = `${startDate} - ${endDate}`;
+    const period = `${startDate} ~ ${endDate}`;
 
     return { goalStatuses, period };
   } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -70,6 +70,11 @@ function createApp(testMode = false) {
         } else if (action.action_id === 'finalize_goals') {
           await goalSetting.finalizeGoalSetting(payload, slack, config.SLACK_CHANNEL_ID);
 
+        // 目標リストから1つ目標削除
+        } else if (action.action_id.startsWith('delete_goal_')) {
+          const index = parseInt(action.action_id.split('_')[2]);
+          await goalSetting.deleteGoal(payload, slack, payload.channel.id, index);
+
         // 週終わりに送信した週間レポートのフィードバックを受け取る -> Notionに送信
         } else if (action.action_id === 'submit_reflection') {
           const userFeedback = payload.state.values.reflection_input.reflection_input.value;


### PR DESCRIPTION
## issue
- #23 
- #24 
- #6 

Close #23, #24, #6

## 作業内容
- 目標リストをサーバー側で管理せず、Slackメッセージから読み取るようにした
- 絵文字選択のインタラクティブメッセージを削除
- 目標設定時に、削除操作を追加

## 動作確認方法
- 開発環境にて確認

## 今後の課題
-
