### PR TITLE
#20 複数ユーザー対応

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,34 @@
 require('dotenv').config();
 const env = process.env.NODE_ENV || 'production';
 
+// カンマ区切りの環境変数を配列として取得
+const USER_IDS = process.env.USER_IDS ? process.env.USER_IDS.split(',') : [];
+const USER_NAMES = process.env.USER_NAMES ? process.env.USER_NAMES.split(',') : [];
+const CHANNEL_IDS = process.env.CHANNEL_IDS ? process.env.CHANNEL_IDS.split(',') : [];
+const WEBHOOK_URLS = process.env.WEBHOOK_URLS ? process.env.WEBHOOK_URLS.split(',') : [];
+
+// 要素数の確認: 要素数が一致しない場合はエラーをスロー
+if (USER_IDS.length !== USER_NAMES.length || USER_IDS.length !== CHANNEL_IDS.length || USER_IDS.length !== WEBHOOK_URLS.length) {
+  throw new Error('USER_IDS, USER_NAMES, CHANNEL_IDS, and WEBHOOK_URLS must have the same number of elements');
+}
+
+// indexだけを使ってループを回すためにforループを使用
+const USERS = [];
+for (let i = 0; i < USER_IDS.length; i++) {
+  USERS.push({
+    USER_ID: USER_IDS[i],
+    USER_NAME: USER_NAMES[i],
+    CHANNEL_ID: CHANNEL_IDS[i],
+    WEBHOOK_URL: WEBHOOK_URLS[i],
+  });
+}
+
 const config = {
   SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN, 
   SLACK_CHANNEL_ID: process.env.SLACK_CHANNEL_ID,
   NOTION_INTEGRATION_TOKEN: process.env.NOTION_INTEGRATION_TOKEN,
   NOTION_DATABASE_ID: process.env.NOTION_DATABASE_ID,
+  USERS,
 
   development: {
     GOAL_SETTING_CRON: '*/1 * * * *',   // 1分に1回
@@ -13,14 +36,8 @@ const config = {
   },
 
   production: {
-    // GOAL_SETTING_CRON: '0 9 * * 0',  // 毎週日曜日の午前9時
-    // WEEKLY_REPORT_CRON: '0 17 * * 5' // 毎週金曜日の午後5時
-    // GOAL_SETTING_CRON: '0 9 * * *',   // 毎日午前9時
-    // WEEKLY_REPORT_CRON: '0 17 * * *'  // 毎日午後5時
-    // GOAL_SETTING_CRON: '*/10 * * * *',   // 10分に1回
-    // WEEKLY_REPORT_CRON: '*/10 * * * *'  // 10分に1回
-    GOAL_SETTING_CRON: '0 * * * *',   // 1時間ごと
-    WEEKLY_REPORT_CRON: '0 * * * *'   // 1時間ごと
+    GOAL_SETTING_CRON: '0 9 * * 0',  // 毎週日曜日の午前9時
+    WEEKLY_REPORT_CRON: '0 17 * * 5' // 毎週金曜日の午後5時
   },
 };
 

--- a/src/messages/goalSettingMessage.js
+++ b/src/messages/goalSettingMessage.js
@@ -2,80 +2,82 @@ require('dotenv').config();
 
 const MAX_GOALS = 15;
 
-const goalSettingMessage = {
-  blocks: [
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `<@${process.env.SLACK_USER_ID}>\n今週の目標を入力してください：`
-      }
-    },
-    {
-      type: "input",
-      block_id: "goal_input",
-      element: {
-        type: "plain_text_input",
-        action_id: "goal_value",
-        placeholder: {
-          type: "plain_text",
-          text: "目標を入力してください"
+function createGoalSettingMessage(userId) {
+  return {
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `<@${userId}>\n今週の目標を入力してください：`
         }
       },
-      label: {
-        type: "plain_text",
-        text: "目標"
-      }
-    },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: {
+      {
+        type: "input",
+        block_id: "goal_input",
+        element: {
+          type: "plain_text_input",
+          action_id: "goal_value",
+          placeholder: {
             type: "plain_text",
-            text: "追加"
-          },
-          style: "primary",
-          action_id: "add_goal"
+            text: "目標を入力してください"
+          }
+        },
+        label: {
+          type: "plain_text",
+          text: "目標"
         }
-      ]
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*今週の目標リスト：*"
-      }
-    },
-    {
-      type: "context",
-      elements: [
-        {
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "追加"
+            },
+            style: "primary",
+            action_id: "add_goal"
+          }
+        ]
+      },
+      {
+        type: "section",
+        text: {
           type: "mrkdwn",
-          text: "目標はまだ追加されていません。"
+          text: "*今週の目標リスト：*"
         }
-      ]
-    },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: {
-            type: "plain_text",
-            text: "目標設定完了"
-          },
-          style: "danger",
-          action_id: "finalize_goals"
-        }
-      ]
-    }
-  ]
-};
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "目標はまだ追加されていません。"
+          }
+        ]
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "目標設定完了"
+            },
+            style: "danger",
+            action_id: "finalize_goals"
+          }
+        ]
+      }
+    ]
+  };
+}
 
 function updateGoalSettingMessage(goals) {
-  const updatedBlocks = [...goalSettingMessage.blocks];
+  const updatedBlocks = [...createGoalSettingMessage().blocks];
 
   const goalListIndex = updatedBlocks.findIndex(block =>
     block.type === "section" && block.text.text === "*今週の目標リスト：*"
@@ -120,6 +122,6 @@ function updateGoalSettingMessage(goals) {
 }
 
 module.exports = {
-  goalSettingMessage,
+  createGoalSettingMessage,
   updateGoalSettingMessage
 };

--- a/src/messages/weeklyReportMessage.js
+++ b/src/messages/weeklyReportMessage.js
@@ -1,6 +1,6 @@
 const { emojiMapping } = require("../utils/emojiMapping");
 
-function weeklyReportMessage(goals, achievementRate, period) {
+function weeklyReportMessage(userId, goals, achievementRate, period) {
   const formattedGoals = goals
     .map(
       (goal, index) =>
@@ -16,7 +16,7 @@ function weeklyReportMessage(goals, achievementRate, period) {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*今週の目標の振り返り (${period})*`,
+          text: `<@${userId}>\n*今週の目標の振り返り (${period})*`,
         },
       },
       {

--- a/src/modules/goalSetting.js
+++ b/src/modules/goalSetting.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const { emojiMapping } = require("../utils/emojiMapping");
 const { goalSettingMessage, updateGoalSettingMessage } = require("../messages/goalSettingMessage");
+const { USERS } = require("../config");
 
 const MAX_GOALS = 15;
 
@@ -9,16 +10,22 @@ function getRandomEmojis(count) {
   return _.shuffle(allEmojis).slice(0, count);
 }
 
-async function initiateGoalSetting(slack, channelId) {
+async function sendMessageToUser(slack, channelId) { 
   try {
     const result = await slack.chat.postMessage({
       channel: channelId,
       ...goalSettingMessage,
     });
-    console.log("Goal setting message sent successfully");
+    console.log(`Message sent successfully to channel: ${channelId}`);
     return result.ts;
   } catch (error) {
-    console.error("Error sending goal setting message:", error);
+    console.error(`Error sending message to channel ${channelId}:`, error);
+  }
+}
+
+async function initiateGoalSetting(slack) {
+  for (const user of USERS) {
+    await sendMessageToUser(slack, user.CHANNEL_ID);
   }
 }
 

--- a/src/modules/goalSetting.js
+++ b/src/modules/goalSetting.js
@@ -29,8 +29,8 @@ async function initiateGoalSetting(slack) {
   }
 }
 
-async function handleGoalSubmission(payload, slack, channelId) {
-  const currentGoals = await getCurrentGoals(slack, channelId, payload.message.ts);
+async function handleGoalSubmission(payload, slack) {
+  const currentGoals = await getCurrentGoals(slack, payload.channel.id, payload.message.ts);
 
   if (currentGoals.length >= MAX_GOALS) {
     try {
@@ -51,7 +51,7 @@ async function handleGoalSubmission(payload, slack, channelId) {
 
   try {
     const result = await slack.chat.update({
-      channel: channelId,
+      channel: payload.channel.id,
       ts: payload.message.ts,
       ...updateGoalSettingMessage(currentGoals),
     });
@@ -62,14 +62,14 @@ async function handleGoalSubmission(payload, slack, channelId) {
   }
 }
 
-async function deleteGoal(payload, slack, channelId, index) {
-  const currentGoals = await getCurrentGoals(slack, channelId, payload.message.ts);
+async function deleteGoal(payload, slack, index) {
+  const currentGoals = await getCurrentGoals(slack, payload.channel.id, payload.message.ts);
 
   currentGoals.splice(index, 1);
 
   try {
     const result = await slack.chat.update({
-      channel: channelId,
+      channel: payload.channel.id,
       ts: payload.message.ts,
       ...updateGoalSettingMessage(currentGoals),
     });
@@ -79,8 +79,8 @@ async function deleteGoal(payload, slack, channelId, index) {
   }
 }
 
-async function finalizeGoalSetting(payload, slack, channelId) {
-  const currentGoals = await getCurrentGoals(slack, channelId, payload.message.ts);
+async function finalizeGoalSetting(payload, slack) {
+  const currentGoals = await getCurrentGoals(slack, payload.channel.id, payload.message.ts);
   const randomEmojis = getRandomEmojis(currentGoals.length);
   const goalsWithRandomEmoji = currentGoals.map((goal, index) => ({
     text: goal.text,
@@ -91,16 +91,16 @@ async function finalizeGoalSetting(payload, slack, channelId) {
 
   try {
     const result = await slack.chat.postMessage({
-      channel: channelId,
+      channel: payload.channel.id,
       text: `今週の目標です：\n${goalListText}`,
     });
 
     for (const goal of goalsWithRandomEmoji) {
-      await addReactionToMessage(slack, channelId, result.ts, goal.emoji);
+      await addReactionToMessage(slack, payload.channel.id, result.ts, goal.emoji);
     }
 
     await slack.chat.delete({
-      channel: channelId,
+      channel: payload.channel.id,
       ts: payload.message.ts,
     });
     console.log("Final goal list sent successfully with reactions");

--- a/src/modules/goalSetting.js
+++ b/src/modules/goalSetting.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { emojiMapping } = require("../utils/emojiMapping");
-const { goalSettingMessage, updateGoalSettingMessage } = require("../messages/goalSettingMessage");
+const { createGoalSettingMessage, updateGoalSettingMessage } = require("../messages/goalSettingMessage");
 const { USERS } = require("../config");
 
 const MAX_GOALS = 15;
@@ -10,11 +10,11 @@ function getRandomEmojis(count) {
   return _.shuffle(allEmojis).slice(0, count);
 }
 
-async function sendMessageToUser(slack, channelId) { 
+async function sendMessageToUser(slack, channelId, userId) { 
   try {
     const result = await slack.chat.postMessage({
       channel: channelId,
-      ...goalSettingMessage,
+      ...createGoalSettingMessage(userId),
     });
     console.log(`Message sent successfully to channel: ${channelId}`);
     return result.ts;
@@ -25,7 +25,7 @@ async function sendMessageToUser(slack, channelId) {
 
 async function initiateGoalSetting(slack) {
   for (const user of USERS) {
-    await sendMessageToUser(slack, user.CHANNEL_ID);
+    await sendMessageToUser(slack, user.CHANNEL_ID, user.USER_ID);
   }
 }
 

--- a/src/modules/sendToNotionDB.js
+++ b/src/modules/sendToNotionDB.js
@@ -6,7 +6,7 @@ const cleanDatabaseId = config.NOTION_DATABASE_ID.trim().replace(/"/g, '');
 
 const notion = new Client({ auth: config.NOTION_INTEGRATION_TOKEN });
 
-async function sendWeeklyDataToNotion(completedTasks, incompleteTasks, feedback, period) {
+async function sendWeeklyDataToNotion(period, userName, completedTasks, incompleteTasks, feedback) {
   try {
 
     console.log('Preparing data for Notion API');
@@ -15,6 +15,9 @@ async function sendWeeklyDataToNotion(completedTasks, incompleteTasks, feedback,
       properties: {
         '期間': {
           title: [{ text: { content: period } }]
+        },
+        'ゆるゆる走者': {
+          rich_text: [{ text: { content: userName } }]
         },
         '完了タスク': {
           rich_text: [{ text: { content: completedTasks } }]

--- a/src/modules/weeklyReport.js
+++ b/src/modules/weeklyReport.js
@@ -58,6 +58,9 @@ async function handleUserFeedback(payload, slack) {
     const { goals, period } = JSON.parse(payload.actions[0].value);
     console.log("Parsed data:", { goals, period });
 
+    // チャンネルに対応するUSERを取得
+    const mentionedUser = USERS.find(user => user.CHANNEL_ID === payload.channel.id);
+
     const completedTasks = goals
       .filter((goal) => goal.isCompleted)
       .map((goal) => `${emojiMapping[goal.emoji].notion} ${goal.text}`);
@@ -66,10 +69,11 @@ async function handleUserFeedback(payload, slack) {
       .map((goal) => `${emojiMapping[goal.emoji].notion} ${goal.text}`);
 
     await sendWeeklyDataToNotion(
+      period,
+      mentionedUser.USER_NAME,
       completedTasks.join("\n") || "なし",
       incompleteTasks.join("\n") || "なし",
-      feedback,
-      period
+      feedback
     );
 
     console.log("Data sent to Notion successfully");

--- a/src/modules/weeklyReport.js
+++ b/src/modules/weeklyReport.js
@@ -2,8 +2,9 @@ const { detectStatuses } = require("./statusDetector");
 const { weeklyReportMessage } = require("../messages/weeklyReportMessage");
 const { sendWeeklyDataToNotion } = require("./sendToNotionDB");
 const { emojiMapping } = require("../utils/emojiMapping");
+const { USERS } = require("../config");
 
-async function generateWeeklyReport(slack, channelId) {
+async function sendMessageToUser(slack, channelId) {
   try {
     console.log("Generating weekly report...");
 
@@ -32,6 +33,12 @@ async function generateWeeklyReport(slack, channelId) {
   } catch (error) {
     console.error("Error generating weekly report:", error);
     throw error;
+  }
+}
+
+async function generateWeeklyReport(slack) {
+  for (const user of USERS) {
+    await sendMessageToUser(slack, user.CHANNEL_ID);
   }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -23,13 +23,12 @@ function createApp(testMode = false) {
     } else if (req.body.event && req.body.event.type === 'app_mention') {
       console.log('App was mentioned!');
   
+      // メンションされたチャンネルに対応するUSERを見つける
       const mentionedChannelId = req.body.event.channel;
-      
-      // メンションされたチャンネルに対応するユーザーを見つける
       const mentionedUser = config.USERS.find(user => user.CHANNEL_ID === mentionedChannelId);
   
+      // 見つかったUSERのWebhook URLにメッセージを送信
       if (mentionedUser) {
-        // 見つかったユーザーのWebhook URLにメッセージを送信
         axios.post(mentionedUser.WEBHOOK_URL, { text: "Gotta get the bread and milk!" }, {
           headers: {
             'Content-Type': 'application/json'

--- a/src/server.js
+++ b/src/server.js
@@ -92,7 +92,7 @@ function createApp(testMode = false) {
             throw new Error('User feedback is empty');
           }
           
-          await weeklyReport.handleUserFeedback(payload, slack, payload.channel.id);
+          await weeklyReport.handleUserFeedback(payload, slack);
         }
       } catch (error) {
         console.error('Error handling action:', error);
@@ -138,13 +138,13 @@ if (process.env.NODE_ENV === 'development') {
     }
   );
   
-  // const scheduleWeeklyReport = scheduler.scheduleJob(
-  //   config.WEEKLY_REPORT_CRON,
-  //   () => {
-  //     console.log('Generating weekly report...');
-  //     weeklyReport.generateWeeklyReport(slack);
-  //   }
-  // );
+  const scheduleWeeklyReport = scheduler.scheduleJob(
+    config.WEEKLY_REPORT_CRON,
+    () => {
+      console.log('Generating weekly report...');
+      weeklyReport.generateWeeklyReport(slack);
+    }
+  );
 }
 
 return { app, scheduler };

--- a/src/server.js
+++ b/src/server.js
@@ -73,16 +73,16 @@ function createApp(testMode = false) {
       try {
         // 週初めに送信した目標設定メッセージにて、目標追加ボタン -> 目標リストに追加して更新
         if (action.action_id === 'add_goal') {
-          await goalSetting.handleGoalSubmission(payload, slack, config.SLACK_CHANNEL_ID);
+          await goalSetting.handleGoalSubmission(payload, slack);
 
         // 目標リストを確定させる
         } else if (action.action_id === 'finalize_goals') {
-          await goalSetting.finalizeGoalSetting(payload, slack, config.SLACK_CHANNEL_ID);
+          await goalSetting.finalizeGoalSetting(payload, slack);
 
         // 目標リストから1つ目標削除
         } else if (action.action_id.startsWith('delete_goal_')) {
           const index = parseInt(action.action_id.split('_')[2]);
-          await goalSetting.deleteGoal(payload, slack, payload.channel.id, index);
+          await goalSetting.deleteGoal(payload, slack, index);
 
         // 週終わりに送信した週間レポートのフィードバックを受け取る -> Notionに送信
         } else if (action.action_id === 'submit_reflection') {
@@ -126,26 +126,26 @@ app.post('/trigger/weekly-report', async (req, res) => {
   }
 });
 
-// // 開発環境の場合、ローカルでスケジューリングを設定
-// if (process.env.NODE_ENV === 'development') {
-//   console.log('Setting up local scheduling...');
+// 開発環境の場合、ローカルでスケジューリングを設定
+if (process.env.NODE_ENV === 'development') {
+  console.log('Setting up local scheduling...');
   
-//   const scheduleGoalSetting = scheduler.scheduleJob(
-//     config.GOAL_SETTING_CRON,
-//     () => {
-//       console.log('Initiating goal setting...');
-//       goalSetting.initiateGoalSetting(slack, config.SLACK_CHANNEL_ID);
-//     }
-//   );
+  const scheduleGoalSetting = scheduler.scheduleJob(
+    config.GOAL_SETTING_CRON,
+    () => {
+      console.log('Initiating goal setting...');
+      goalSetting.initiateGoalSetting(slack);
+    }
+  );
   
-//   const scheduleWeeklyReport = scheduler.scheduleJob(
-//     config.WEEKLY_REPORT_CRON,
-//     () => {
-//       console.log('Generating weekly report...');
-//       weeklyReport.generateWeeklyReport(slack, config.SLACK_CHANNEL_ID);
-//     }
-//   );
-// }
+  // const scheduleWeeklyReport = scheduler.scheduleJob(
+  //   config.WEEKLY_REPORT_CRON,
+  //   () => {
+  //     console.log('Generating weekly report...');
+  //     weeklyReport.generateWeeklyReport(slack);
+  //   }
+  // );
+}
 
 return { app, scheduler };
 }


### PR DESCRIPTION
## issue
- #20

Close #20

## 作業内容
- USERSを.env->configに複数用意
- スケジュールトリガー時にUSERリストから逐次的に送信

.env以下情報を設定する
```
USER_IDS=AAA,BBB
USER_NAMES=aaa,bbb
CHANNEL_IDS=AAA,BBB
WEBHOOK_URLS=https://xxx,https://yyy 
```

config.jsにてUSERSを用意（コンマで区切る）

```js
const USERS = [];
for (let i = 0; i < USER_IDS.length; i++) {
  USERS.push({
    USER_ID: USER_IDS[i],
    USER_NAME: USER_NAMES[i],
    CHANNEL_ID: CHANNEL_IDS[i],
    WEBHOOK_URL: WEBHOOK_URLS[i],
  });
}
```

- 各設定値
  - USER_ID: メンション時に使用
  - USER_NAME: Notion DBへ送信
  - CHANNEL_ID: メッセージ送信時、および取得情報のUSER取得時の照合用

## 動作確認方法
- 開発環境で確認

## 今後の課題
-
