### PR TITLE
#29 週間レポート上でも達成状況を更新

### DIFF
--- a/src/messages/weeklyReportMessage.js
+++ b/src/messages/weeklyReportMessage.js
@@ -1,15 +1,6 @@
 const { emojiMapping } = require("../utils/emojiMapping");
 
 function weeklyReportMessage(userId, goals, achievementRate, period) {
-  const formattedGoals = goals
-    .map(
-      (goal, index) =>
-        `${index + 1}. ${emojiMapping[goal.emoji].notion} ${goal.text} ${
-          goal.isCompleted ? "✅" : "⬜"
-        }`
-    )
-    .join("\n");
-
   return {
     blocks: [
       {
@@ -19,18 +10,49 @@ function weeklyReportMessage(userId, goals, achievementRate, period) {
           text: `<@${userId}>\n*今週の目標の振り返り (${period})*`,
         },
       },
-      {
+      ...goals.map((goal, index) => ({
         type: "section",
+        block_id: `goal_status_${index}`,
         text: {
           type: "mrkdwn",
-          text: formattedGoals,
+          text: `${index + 1}. ${emojiMapping[goal.emoji].notion} ${goal.text} ${goal.isCompleted ? "✅" : "⬜"}`,
         },
-      },
+        accessory: {
+          type: "static_select",
+          action_id: `goal_status_change_${index}`,
+          initial_option: {
+            text: {
+              type: "plain_text",
+              text: goal.isCompleted ? "達成" : "未達成",
+              emoji: true,
+            },
+            value: goal.isCompleted ? "completed" : "incomplete",
+          },
+          options: [
+            {
+              text: {
+                type: "plain_text",
+                text: "達成",
+                emoji: true,
+              },
+              value: "completed",
+            },
+            {
+              text: {
+                type: "plain_text",
+                text: "未達成",
+                emoji: true,
+              },
+              value: "incomplete",
+            },
+          ],
+        },
+      })),
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `全体の達成率: ${achievementRate}%`,
+          text: `達成率: ${achievementRate}%`,
         },
       },
       {

--- a/src/modules/statusDetector.js
+++ b/src/modules/statusDetector.js
@@ -38,7 +38,7 @@ async function getWeeklyGoals(slack, channelId) {
     console.log(`Attempting to retrieve messages from channel: ${channelId}`);
     const result = await slack.conversations.history({
       channel: channelId,
-      limit: 100, // 適切な数に調整してください
+      limit: 1000,
     });
 
     console.log(

--- a/src/modules/weeklyReport.js
+++ b/src/modules/weeklyReport.js
@@ -56,15 +56,21 @@ async function handleUserFeedback(payload, slack) {
     }
 
     const { goals, period } = JSON.parse(payload.actions[0].value);
-    console.log("Parsed data:", { goals, period });
+    
+    // static_selectの状態を取得して目標の達成状態を更新
+    const updatedGoals = goals.map((goal, index) => ({
+      ...goal,
+      isCompleted: payload.state.values[`goal_status_${index}`][`goal_status_change_${index}`].selected_option.value === "completed",
+      finalStatus: payload.state.values[`goal_status_${index}`][`goal_status_change_${index}`].selected_option.value === "completed" ? "達成" : "未達成"
+    }));
 
     // チャンネルに対応するUSERを取得
     const mentionedUser = USERS.find(user => user.CHANNEL_ID === payload.channel.id);
 
-    const completedTasks = goals
+    const completedTasks = updatedGoals
       .filter((goal) => goal.isCompleted)
       .map((goal) => `${emojiMapping[goal.emoji].notion} ${goal.text}`);
-    const incompleteTasks = goals
+    const incompleteTasks = updatedGoals
       .filter((goal) => !goal.isCompleted)
       .map((goal) => `${emojiMapping[goal.emoji].notion} ${goal.text}`);
 
@@ -78,9 +84,13 @@ async function handleUserFeedback(payload, slack) {
 
     console.log("Data sent to Notion successfully");
 
+    const updatedAchievementRate = Math.round(
+      (completedTasks.length / updatedGoals.length) * 100
+    );
+
     await slack.chat.postMessage({
       channel: payload.channel.id,
-      text: "Notionへ送信しました。1週間お疲れ様！",
+      text: `最終達成率: ${updatedAchievementRate}%\nNotionへ送信しました。1週間お疲れ様！`,
     });
   } catch (error) {
     console.error("Error handling user feedback:", error);

--- a/src/utils/emojiMapping.js
+++ b/src/utils/emojiMapping.js
@@ -50,7 +50,6 @@ const emojiMapping = {
   clown_face: { reaction: 'clown_face', notion: '🤡' },
   egg: { reaction: 'egg', notion: '🥚' },
   see_no_evil: { reaction: 'see_no_evil', notion: '🙈' },
-  camera_flash: { reaction: 'camera_flash', notion: '📸' },
   alembic: { reaction: 'alembic', notion: '⚗️' },
   mag: { reaction: 'mag', notion: '🔍️' },
   label: { reaction: 'label', notion: '🏷️' },


### PR DESCRIPTION
## issue
- #29 

Close #29 

## 作業内容
- 週間レポート上でも達成状況を更新できるセレクトボタンを追加
- 絵文字からcamera_flashを削除（slackに存在しないため）
- 履歴を1000件まで遡れるように修正

## 動作確認方法
-

## 今後の課題
-
